### PR TITLE
create endpoint PATCH /api/articles/:article_id and handle associated errors

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -83,7 +83,7 @@ describe("app.js", () => {
       });
     });
     describe("PATCH", () => {
-      test("status:20, updates the correct article_id with the amount of votes entered and returns updated article object", () => {
+      test("status:200, updates the correct article_id with the amount of votes entered and returns updated article object", () => {
         return request(app)
           .patch("/api/articles/1")
           .send({ inc_votes: 100 })

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -16,61 +16,137 @@ describe("app.js", () => {
         expect(body).toEqual({ msg: "Path not found" });
       });
   });
-  describe("GET /api/topics", () => {
-    test("status:200, returns an array of topic objects", () => {
-      return request(app)
-        .get("/api/topics")
-        .expect(200)
-        .then(({ body }) => {
-          body.forEach((topic) =>
-            expect(topic).toEqual(
-              expect.objectContaining({
-                slug: expect.any(String),
-                description: expect.any(String),
-              })
-            )
-          );
-        });
+  describe("/api/topics", () => {
+    describe("GET", () => {
+      test("status:200, returns an array of topic objects", () => {
+        return request(app)
+          .get("/api/topics")
+          .expect(200)
+          .then(({ body }) => {
+            body.forEach((topic) =>
+              expect(topic).toEqual(
+                expect.objectContaining({
+                  slug: expect.any(String),
+                  description: expect.any(String),
+                })
+              )
+            );
+          });
+      });
     });
   });
-  describe("GET /api/articles/:article_id", () => {
-    test("status:200, returns an article object when passed a valid article_id", () => {
-      return request(app)
-        .get("/api/articles/1")
-        .expect(200)
-        .then(({ body }) => {
-          expect(body).toEqual(
-            expect.objectContaining({
-              article_id: 1,
-              title: "Living in the shadow of a great man",
-              topic: "mitch",
-              author: "butter_bridge",
-              body: "I find this existence challenging",
-              created_at: "2020-07-09T20:11:00.000Z",
-              votes: 100,
-            })
-          );
-        });
+  describe("/api/articles/:article_id", () => {
+    describe("GET", () => {
+      test("status:200, returns an article object when passed a valid article_id", () => {
+        return request(app)
+          .get("/api/articles/1")
+          .expect(200)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                article_id: 1,
+                title: "Living in the shadow of a great man",
+                topic: "mitch",
+                author: "butter_bridge",
+                body: "I find this existence challenging",
+                created_at: "2020-07-09T20:11:00.000Z",
+                votes: 100,
+              })
+            );
+          });
+      });
+      test("status:400, returns error message when passed an invalid article_id", () => {
+        return request(app)
+          .get("/api/articles/seven';-- yo")
+          .expect(400)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                msg: "Invalid input",
+              })
+            );
+          });
+      });
+      test("status:404, returns article not found when passed non-existent article_id", () => {
+        return request(app)
+          .get("/api/articles/1688")
+          .expect(404)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                msg: "Article not found",
+              })
+            );
+          });
+      });
     });
-    test("status:400, returns error message when passed an invalid article_id", () => {
-      return request(app)
-        .get("/api/articles/seven';-- yo")
-        .expect(400)
-        .then(({ body }) => {
-          expect(body).toEqual(
-            expect.objectContaining({
-              msg: "Invalid input",
-            })
-          );
-        });
-    });
-    test("status:400, returns article not found when passed non-existent article_id", () => {
-      return request(app)
-        .get("/api/articles/1688")
-        .expect(400)
-        .then(({ body }) => {
-          expect(body.msg).toBe("Article not found");
-        });
+    describe("PATCH", () => {
+      test("status:204, updates the correct article_id with the amount of votes entered", () => {
+        return request(app)
+          .patch("/api/articles/1")
+          .send({ inc_votes: 100 })
+          .expect(204)
+          .then(() => {
+            return request(app)
+              .get("/api/articles/1")
+              .expect(200)
+              .then(({ body }) => {
+                expect(body.votes).toBe(200);
+              });
+          });
+      });
+      test("status:400, returns invalid input when passed invalid article_id", () => {
+        return request(app)
+          .patch("/api/articles/eight")
+          .send({ inc_votes: 100 })
+          .expect(400)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                msg: "Invalid input",
+              })
+            );
+          });
+      });
+      test("status:400, returns invalid input when passed invalid patch body (invalid value)", () => {
+        return request(app)
+          .patch("/api/articles/eight")
+          .send({ inc_votes: "not-a-valid-value" })
+          .expect(400)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                msg: "Invalid input",
+              })
+            );
+          });
+      });
+      test("status:400, returns invalid inputwhen passed invalid patch body (invalid key)", () => {
+        return request(app)
+          .patch("/api/articles/eight")
+          .send({ "not a valid key": 100 })
+          .expect(400)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                msg: "Invalid input",
+              })
+            );
+          });
+      });
+      test("status:404, returns article not found when passed non-existent article_id", () => {
+        return request(app)
+          .patch("/api/articles/1688")
+          .send({ inc_votes: 100 })
+          .expect(404)
+          .then(({ body }) => {
+            expect(body).toEqual(
+              expect.objectContaining({
+                msg: "Article not found",
+              })
+            );
+          });
+      });
     });
   });
 });

--- a/app.js
+++ b/app.js
@@ -1,7 +1,11 @@
 const express = require("express");
 const app = express();
 
-const { getTopics, getArticleById } = require("./controllers/controllers");
+const {
+  getTopics,
+  getArticleById,
+  patchArticleById,
+} = require("./controllers/controllers");
 const {
   trigger404,
   psqlErrors,
@@ -15,6 +19,7 @@ app.get("/api/topics", getTopics);
 
 // articles
 app.get("/api/articles/:article_id", getArticleById);
+app.patch("/api/articles/:article_id", patchArticleById);
 
 // errors
 app.all("/*", trigger404);

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,4 +1,8 @@
-const { fetchTopics, fetchArticle } = require("../models/models");
+const {
+  fetchTopics,
+  fetchArticle,
+  updateArticleById,
+} = require("../models/models");
 
 exports.getTopics = async (req, res, next) => {
   try {
@@ -13,10 +17,31 @@ exports.getArticleById = async (req, res, next) => {
   try {
     const { article_id: id } = req.params;
     const { rows: article } = await fetchArticle(id);
+
     if (article.length === 1) {
       res.status(200).send(article[0]);
     } else {
-      next({ status: 400, msg: "Article not found" });
+      next({ status: 404, msg: "Article not found" });
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.patchArticleById = async (req, res, next) => {
+  try {
+    const { inc_votes: number } = req.body;
+    const { article_id: id } = req.params;
+
+    // check to see if article_id exists in db
+    const { rows: article } = await fetchArticle(id);
+    if (article.length === 1) {
+      // if exists then patch
+      await updateArticleById(id, number);
+      res.status(204).send();
+    } else {
+      // otherwise throw 404
+      next({ status: 404, msg: "Article not found" });
     }
   } catch (err) {
     next(err);

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -1,3 +1,4 @@
+const { convertTimestampToDate } = require("../db/helpers/utils");
 const {
   fetchTopics,
   fetchArticle,
@@ -37,8 +38,8 @@ exports.patchArticleById = async (req, res, next) => {
     const { rows: article } = await fetchArticle(id);
     if (article.length === 1) {
       // if exists then patch
-      await updateArticleById(id, number);
-      res.status(204).send();
+      const { rows: patchedArticle } = await updateArticleById(id, number);
+      res.status(200).send(patchedArticle[0]);
     } else {
       // otherwise throw 404
       next({ status: 404, msg: "Article not found" });

--- a/models/models.js
+++ b/models/models.js
@@ -7,3 +7,14 @@ exports.fetchTopics = async () => {
 exports.fetchArticle = async (id) => {
   return await db.query(`SELECT * FROM articles WHERE article_id = $1`, [id]);
 };
+
+exports.updateArticleById = async (id, number) => {
+  return await db.query(
+    `
+  UPDATE articles 
+  SET votes = votes + $1
+  WHERE article_id = $2
+  RETURNING *;`,
+    [number, id]
+  );
+};


### PR DESCRIPTION
create new endpoint PATCH /api/artciles/:article_id with tests

- status: 200, returns an article object when passed valid article_id
- status: 400, returns invalid input when passed an invalid article_id
- status: 400, returns invalid input when passed an invalid body key
- status: 400, returns invalid input when passed an invalid body value
- status: 404, returns article not found when passed a valid but non-existent article_id
- slight refactor of older tests

update as per dav3rid comments below