### PR TITLE
Ncnews 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 .env.*
+query.sql
+output.txt

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -96,9 +96,15 @@ describe("app.js", () => {
         return request(app)
           .get("/api/articles/1")
           .expect(200)
-          .then(({ body: { comment_count } }) => {
-            expect(comment_count).toBe(11);
-          });
+          .then(
+            ({
+              body: {
+                article: { comment_count },
+              },
+            }) => {
+              expect(comment_count).toBe(11);
+            }
+          );
       });
       test("status:400, returns error message when passed an invalid article_id", () => {
         return request(app)

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,7 +3,6 @@ const request = require("supertest");
 const seed = require("../db/seeds/seed");
 const data = require("../db/data/test-data");
 const db = require("../db/connection");
-const { convertTimestampToDate } = require("../db/helpers/utils");
 
 afterAll(() => db.end());
 beforeEach(() => seed(data));
@@ -38,7 +37,7 @@ describe("app.js", () => {
     });
   });
   describe("/api/articles", () => {
-    describe.only("GET", () => {
+    describe("GET", () => {
       test("status:200, returns an array of articles", () => {
         return request(app)
           .get("/api/articles")
@@ -46,14 +45,14 @@ describe("app.js", () => {
           .then(({ body: { articles } }) => {
             expect(articles).toHaveLength(12);
             articles.forEach((article) => {
-              expect(convertTimestampToDate(article)).toEqual(
+              expect(article).toEqual(
                 expect.objectContaining({
                   article_id: expect.any(Number),
                   title: expect.any(String),
                   topic: expect.any(String),
                   author: expect.any(String),
                   body: expect.any(String),
-                  created_at: expect.any(Date),
+                  created_at: expect.any(String),
                   votes: expect.any(Number),
                 })
               );
@@ -80,17 +79,25 @@ describe("app.js", () => {
           .get("/api/articles/1")
           .expect(200)
           .then(({ body: { article } }) => {
-            expect(convertTimestampToDate(article)).toEqual(
+            expect(article).toEqual(
               expect.objectContaining({
                 article_id: 1,
                 title: "Living in the shadow of a great man",
                 topic: "mitch",
                 author: "butter_bridge",
                 body: "I find this existence challenging",
-                created_at: expect.any(Date),
+                created_at: expect.any(String),
                 votes: 100,
               })
             );
+          });
+      });
+      test("status:200, also returns key of comments_count with value of how many comments an article has", () => {
+        return request(app)
+          .get("/api/articles/1")
+          .expect(200)
+          .then(({ body: { comment_count } }) => {
+            expect(comment_count).toBe(11);
           });
       });
       test("status:400, returns error message when passed an invalid article_id", () => {
@@ -125,14 +132,14 @@ describe("app.js", () => {
           .send({ inc_votes: 100 })
           .expect(200)
           .then(({ body: { article } }) => {
-            expect(convertTimestampToDate(article)).toEqual(
+            expect(article).toEqual(
               expect.objectContaining({
                 article_id: 1,
                 title: "Living in the shadow of a great man",
                 topic: "mitch",
                 author: "butter_bridge",
                 body: "I find this existence challenging",
-                created_at: expect.any(Date),
+                created_at: expect.any(String),
                 votes: 200,
               })
             );

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -102,7 +102,7 @@ describe("app.js", () => {
                 article: { comment_count },
               },
             }) => {
-              expect(comment_count).toBe(11);
+              expect(comment_count).toBe("11");
             }
           );
       });
@@ -201,27 +201,6 @@ describe("app.js", () => {
                 msg: "Article not found",
               })
             );
-          });
-      });
-    });
-  });
-  describe("/api/users", () => {
-    describe("GET", () => {
-      test("status:200, returns an array of user objects", () => {
-        return request(app)
-          .get("/api/users")
-          .expect(200)
-          .then(({ body: { users } }) => {
-            expect(users).toHaveLength(4);
-            users.forEach((user) => {
-              expect(user).toEqual(
-                expect.objectContaining({
-                  username: expect.any(String),
-                  name: expect.any(String),
-                  avatar_url: expect.any(String),
-                })
-              );
-            });
           });
       });
     });

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -22,7 +22,8 @@ exports.getArticleById = async (req, res, next) => {
       fetchArticle(id),
       fetchCommentsByArticleId(id),
     ]);
-    res.status(200).send({ article, comment_count: comments.length });
+    article.comment_count = comments.length;
+    res.status(200).send({ article });
   } catch (err) {
     next(err);
   }

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -1,4 +1,3 @@
-const { convertTimestampToDate } = require("../db/helpers/utils");
 const {
   fetchArticle,
   updateArticleById,

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -4,6 +4,8 @@ const {
   fetchAllArticles,
 } = require("../models/articles-models");
 
+const { fetchCommentsByArticleId } = require("../models/comments-models");
+
 exports.getArticles = async (req, res, next) => {
   try {
     const { rows: articles } = await fetchAllArticles();
@@ -16,8 +18,11 @@ exports.getArticles = async (req, res, next) => {
 exports.getArticleById = async (req, res, next) => {
   try {
     const { article_id: id } = req.params;
-    const article = await fetchArticle(id);
-    res.status(200).send({ article });
+    const [article, { rows: comments }] = await Promise.all([
+      fetchArticle(id),
+      fetchCommentsByArticleId(id),
+    ]);
+    res.status(200).send({ article, comment_count: comments.length });
   } catch (err) {
     next(err);
   }

--- a/controllers/articles-controllers.js
+++ b/controllers/articles-controllers.js
@@ -4,8 +4,6 @@ const {
   fetchAllArticles,
 } = require("../models/articles-models");
 
-const { fetchCommentsByArticleId } = require("../models/comments-models");
-
 exports.getArticles = async (req, res, next) => {
   try {
     const { rows: articles } = await fetchAllArticles();
@@ -18,11 +16,7 @@ exports.getArticles = async (req, res, next) => {
 exports.getArticleById = async (req, res, next) => {
   try {
     const { article_id: id } = req.params;
-    const [article, { rows: comments }] = await Promise.all([
-      fetchArticle(id),
-      fetchCommentsByArticleId(id),
-    ]);
-    article.comment_count = comments.length;
+    const article = await fetchArticle(id);
     res.status(200).send({ article });
   } catch (err) {
     next(err);

--- a/models/articles-models.js
+++ b/models/articles-models.js
@@ -6,7 +6,11 @@ exports.fetchAllArticles = async () => {
 
 exports.fetchArticle = async (id) => {
   const { rows } = await db.query(
-    `SELECT * FROM articles WHERE article_id = $1`,
+    `SELECT articles.*, COUNT(comments.comment_id) AS comment_count
+    FROM articles
+    LEFT JOIN comments ON articles.article_id = comments.article_id
+    WHERE articles.article_id = $1
+    GROUP BY articles.article_id;`,
     [id]
   );
   // if article exists return article

--- a/models/comments-models.js
+++ b/models/comments-models.js
@@ -1,5 +1,0 @@
-const db = require("../db/connection");
-
-exports.fetchCommentsByArticleId = async (id) => {
-  return await db.query(`SELECT * FROM comments WHERE article_id = $1`, [id]);
-};

--- a/models/comments-models.js
+++ b/models/comments-models.js
@@ -1,0 +1,5 @@
+const db = require("../db/connection");
+
+exports.fetchCommentsByArticleId = async (id) => {
+  return await db.query(`SELECT * FROM comments WHERE article_id = $1`, [id]);
+};


### PR DESCRIPTION
Ticket 5
- Add comment_count functionality to endpoint GET /api/articles/:article_id
- refactor some tests to remove use of convertTimestampToDate
- EDIT: refactor to make comment_count a key on the article object, instead of being a key on the body object
- EDIT2: refactor as per popatre comments, using psql join to solve ticket